### PR TITLE
Fix getChatHistory in risuaccess MCP

### DIFF
--- a/src/ts/process/mcp/risuaccess.ts
+++ b/src/ts/process/mcp/risuaccess.ts
@@ -561,8 +561,12 @@ Character fields:
             offset = 0;
         }
 
-        const history = char.chats[char.chatPage].message.slice(offset, offset + count);
-        
+        // To get "newest first", we must reverse the array.
+        const reversedMessages = [...char.chats[char.chatPage].message].reverse();
+    
+        // Now that the array is sorted from newest to oldest, we can slice it
+        const history = reversedMessages.slice(offset, offset + count);
+    
         const ordered =  history.map((entry) => ({
             type: 'text',
             text: `${entry.role === 'char' ? char.name : 'User'}: ${entry.data}`


### PR DESCRIPTION
fixed getChatHistory function to return newest chat first

# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [ ] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
