### PR TITLE
Optimize pargeChunks with bulk removal for NodeStorage

### DIFF
--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -397,12 +397,14 @@ app.post('/api/remove-bulk', async (req, res, next) => {
     }
 
     try {
-        for(const filePath of filePaths){
-            if(!isHex(filePath)){
-                continue;
-            }
-            await fs.rm(path.join(savePath, filePath), { force: true });
+        const validFiles = filePaths.filter(filePath => isHex(filePath));
+        const BATCH_SIZE = 100;
+
+        for (let i = 0; i < validFiles.length; i += BATCH_SIZE) {
+            const batch = validFiles.slice(i, i + BATCH_SIZE);
+            await Promise.all(batch.map(f => fs.rm(path.join(savePath, f), { force: true })));
         }
+
         res.send({
             success: true,
         });

--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -380,6 +380,37 @@ app.get('/api/remove', async (req, res, next) => {
     }
 });
 
+app.post('/api/remove-bulk', async (req, res, next) => {
+    if(req.headers['risu-auth'].trim() !== password.trim()){
+        console.log('incorrect')
+        res.status(400).send({
+            error:'Password Incorrect'
+        });
+        return
+    }
+    const filePaths = req.body;
+    if (!filePaths || !Array.isArray(filePaths)) {
+        res.status(400).send({
+            error:'File paths array required'
+        });
+        return;
+    }
+
+    try {
+        for(const filePath of filePaths){
+            if(!isHex(filePath)){
+                continue;
+            }
+            await fs.rm(path.join(savePath, filePath), { force: true });
+        }
+        res.send({
+            success: true,
+        });
+    } catch (error) {
+        next(error);
+    }
+});
+
 app.get('/api/list', async (req, res, next) => {
     if(req.headers['risu-auth'].trim() !== password.trim()){
         console.log('incorrect')

--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -26,7 +26,6 @@ import { defaultJailbreak, defaultMainPrompt, oldJailbreak, oldMainPrompt } from
 import { loadRisuAccountData } from "./drive/accounter";
 import { decodeRisuSave, encodeRisuSaveCompressionStream, encodeRisuSaveLegacy, RisuSaveEncoder, RisuSavePatcher, type toSaveType } from "./storage/risuSave";
 import { AutoStorage } from "./storage/autoStorage";
-import { NodeStorage } from "./storage/nodeStorage";
 import { updateAnimationSpeed } from "./gui/animation";
 import { updateColorScheme, updateTextThemeAndCSS } from "./gui/colorscheme";
 import { autoServerBackup, saveDbKei } from "./kei/backup";
@@ -1523,14 +1522,13 @@ async function pargeChunks(){
                 toRemove.push(asset)
             }
         }
-        if(forageStorage.realStorage instanceof NodeStorage){
-            if(toRemove.length > 0){
+        if(toRemove.length > 0){
+            try {
                 await forageStorage.removeItems(toRemove)
-            }
-        }
-        else{
-            for(const asset of toRemove){
-                await forageStorage.removeItem(asset)
+            } catch (error) {
+                for(const asset of toRemove){
+                    await forageStorage.removeItem(asset)
+                }
             }
         }
     }

--- a/src/ts/globalApi.svelte.ts
+++ b/src/ts/globalApi.svelte.ts
@@ -26,6 +26,7 @@ import { defaultJailbreak, defaultMainPrompt, oldJailbreak, oldMainPrompt } from
 import { loadRisuAccountData } from "./drive/accounter";
 import { decodeRisuSave, encodeRisuSaveCompressionStream, encodeRisuSaveLegacy, RisuSaveEncoder, RisuSavePatcher, type toSaveType } from "./storage/risuSave";
 import { AutoStorage } from "./storage/autoStorage";
+import { NodeStorage } from "./storage/nodeStorage";
 import { updateAnimationSpeed } from "./gui/animation";
 import { updateColorScheme, updateTextThemeAndCSS } from "./gui/colorscheme";
 import { autoServerBackup, saveDbKei } from "./kei/backup";
@@ -1510,6 +1511,7 @@ async function pargeChunks(){
     }
     else{
         const indexes = await forageStorage.keys()
+        let toRemove:string[] = []
         for(const asset of indexes){
             if(!asset.startsWith('assets/')){
                 continue
@@ -1518,6 +1520,16 @@ async function pargeChunks(){
             if(unpargeable.has(n)){
             }
             else{
+                toRemove.push(asset)
+            }
+        }
+        if(forageStorage.realStorage instanceof NodeStorage){
+            if(toRemove.length > 0){
+                await forageStorage.removeItems(toRemove)
+            }
+        }
+        else{
+            for(const asset of toRemove){
                 await forageStorage.removeItem(asset)
             }
         }

--- a/src/ts/storage/autoStorage.ts
+++ b/src/ts/storage/autoStorage.ts
@@ -46,10 +46,7 @@ export class AutoStorage{
 
     async removeItems(keys:string[]){
         await this.Init()
-        if (this.realStorage instanceof NodeStorage) {
-            return await (this.realStorage as NodeStorage).removeItems(keys)
-        }
-        throw "removeItems Error: Not NodeStorage"
+        return await (this.realStorage as any).removeItems(keys)
     }
 
     async patchItem(key: string, patchData: {patch: any[], expectedHash: string}): Promise<boolean> {

--- a/src/ts/storage/autoStorage.ts
+++ b/src/ts/storage/autoStorage.ts
@@ -44,6 +44,14 @@ export class AutoStorage{
         return await this.realStorage.removeItem(key)
     }
 
+    async removeItems(keys:string[]){
+        await this.Init()
+        if (this.realStorage instanceof NodeStorage) {
+            return await (this.realStorage as NodeStorage).removeItems(keys)
+        }
+        throw "removeItems Error: Not NodeStorage"
+    }
+
     async patchItem(key: string, patchData: {patch: any[], expectedHash: string}): Promise<boolean> {
         await this.Init()
         // Only NodeStorage supports patching for now

--- a/src/ts/storage/nodeStorage.ts
+++ b/src/ts/storage/nodeStorage.ts
@@ -79,6 +79,27 @@ export class NodeStorage{
         }
     }
 
+    async removeItems(keys:string[]){
+        await this.checkAuth()
+        const keysHex = keys.map((key) => Buffer.from(key, 'utf-8').toString('hex'))
+
+        const da = await fetch('/api/remove-bulk', {
+            method: "POST",
+            body: JSON.stringify(keysHex),
+            headers: {
+                'content-type': 'application/json',
+                'risu-auth': auth
+            }
+        })
+        if(da.status < 200 || da.status >= 300){
+            throw "removeItems Error"
+        }
+        const data = await da.json()
+        if(data.error){
+            throw data.error
+        }
+    }
+
     async patchItem(key: string, patchData: {patch: any[], expectedHash: string}): Promise<boolean> {
         await this.checkAuth()
         


### PR DESCRIPTION
This PR implements a performance optimization for the `pargeChunks` (checking unnecessary files) step.

Previously, `pargeChunks` would iterate through all files and make individual `removeItem` API calls for each file to be deleted. This was inefficient, especially with a large number of files.

This change introduces a bulk deletion mechanism:
1.  **Backend**: A new `/api/remove-bulk` endpoint allows deleting a list of files in a single request.
2.  **Client**: `NodeStorage` now has a `removeItems` method that calls this endpoint.
3.  **Usage**: `pargeChunks` now collects the list of files to be removed and calls `removeItems` if the storage backend is `NodeStorage`. For other storage types (like IndexedDB via LocalForage), it falls back to the original behavior of sequential `removeItem` calls.

This dramatically reduces the number of network round-trips during the cleanup phase.

---
*PR created automatically by Jules for task [12283851855221772191](https://jules.google.com/task/12283851855221772191) started by @kangjoseph90*